### PR TITLE
fix spelling mistake

### DIFF
--- a/app/src/main/assets/stories/an_androids_tale.xml
+++ b/app/src/main/assets/stories/an_androids_tale.xml
@@ -784,7 +784,7 @@ You put on your Daydream headset...
             emoji="&#x1F647;">
             <Scenario
                 scenario_type="5"
-                emoji="&#x1F51A;">The bicycle begins to slow down rapidly as the rider hastily applies the breaks.
+                emoji="&#x1F51A;">The bicycle begins to slow down rapidly as the rider hastily applies the brakes.
 It stops just before you and the owner is not impressed.
 The Android huffs and rides away.
 "That was close" you mutter out loud, wondering how you could have handled the situation better.


### PR DESCRIPTION
bicycles have [brakes](https://en.wiktionary.org/wiki/brake#Noun_4), not breaks 🚲 